### PR TITLE
Security Group for upcomming EC2 webserver

### DIFF
--- a/sg.tf
+++ b/sg.tf
@@ -1,0 +1,34 @@
+resource "aws_security_group" "website_sg" {
+  name        = "website_sg"
+  description = "Security group for Website instance"
+
+  vpc_id = aws_vpc.website_vpc.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.cidr_block
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.cidr_block
+  }
+
+  egress {
+    description = "All traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = var.cidr_block
+  }
+
+  tags = merge(local.tags, {
+    "Name" = "${var.tagName}-SG"
+  })    
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "tags" {
 
 # VPC Variables
 variable "cidr_block" {
-  default = "0.0.0.0/0"
+  default = ["0.0.0.0/0"]
 }
 
 variable "availability_zone" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -36,7 +36,7 @@ resource "aws_route_table" "Public_RouteTable" {
 
   # route to IGW
   route {
-    cidr_block = var.cidr_block
+    cidr_block = var.cidr_block[0]
     gateway_id = aws_internet_gateway.igw.id
   }
   tags = merge(local.tags, {


### PR DESCRIPTION
created Security Group for EC2 Instance (allowing port 80, 22) & had to adjust cidr_block variable to a list of strings, therefore setting cidr-block count for public route table route to 0